### PR TITLE
remove parameter from the base that causes an error.

### DIFF
--- a/pipey.Makefile
+++ b/pipey.Makefile
@@ -16,7 +16,7 @@ no_targets__:
 docker-buil%:
 	touch ~/.pipey.config
 	touch local.config
-	docker build --pull $(DOCKER_BUILD_OPTS) -t $(PKG_NAME) .
+	docker build $(DOCKER_BUILD_OPTS) -t $(PKG_NAME) .
 	@$(DONE)
 
 docker-shel%: docker-build


### PR DESCRIPTION
I've had to remove this from the last 2 pipey jobs i've made. Figured i'd just make a commit to clean it up?

@sarah-johnson or @iversonk or @bshelton229. Maybe it was for the old version of docker? 

error: 
```Locals-MacBook-Pro:pipey-chattermill ericfrauel$ make docker-run
touch ~/.pipey.config
touch local.config
docker build --pull  -t roverdotcom/rover-data-pipeline-chattermill:latest .
Sending build context to Docker daemon  18.94kB
Step 1/4 : FROM roverdotcom/rover-data-pipeline-base:latest
pull access denied for roverdotcom/rover-data-pipeline-base, repository does not exist or may require 'docker login'
make: *** [docker-build] Error 1```
