### PR TITLE
with corresponding changes to the templates, the docker-harness metho…

### DIFF
--- a/pipey.Makefile
+++ b/pipey.Makefile
@@ -27,6 +27,10 @@ docker-tes%: docker-build
 	docker run --rm $(DOCKER_RUN_OPTS) $(PKG_NAME) nosetests
 	@$(DONE)
 
+docker-harnes%: docker-build
+	docker run --rm -it $(DOCKER_RUN_OPTS) --entrypoint=/bin/sh $(PKG_NAME) go_test.sh
+	@$(DONE)
+
 docker-ru%: docker-build
 	docker run --rm -it $(DOCKER_RUN_OPTS) $(PKG_NAME)
 	@$(DONE)


### PR DESCRIPTION
…d invoked will drop into a shell, go-test.sh, which in addition to replicating the existing functionality of nosetests, will setup docker environment (e.g. tunnnel, validate config, etc).  finding a descriptive name that wasn't test or shell is challenging, feedback appreciated